### PR TITLE
Separate editor and terminal triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,42 +5,59 @@ https://github.com/rusiaaman/wcgw.git
 
 ## Features
 
-- Share code snippets with custom context to Claude
+- Share code snippets from editor with context to Claude
+- Share terminal output with context
 - Add helpful instructions or descriptions for each share
-- Works both with and without code selection
+- Works with editor or terminal selections
 
 ## How to Use
 
-1. Optional: Select code you want to share
-2. Press `Cmd+'` (Mac) or run command "WCGW: Send to Application"
+### For Editor Content
+1. Select code in the editor you want to share
+2. Press `Cmd+'` (Mac) or run command "WCGW: Send Editor Selection to Application"
 3. Enter helpful text/instructions (or press Escape for default)
 4. Extension will:
    - Switch to Claude
    - Type your instructions
-   - Include code (if selected) and context information
+   - Include selected code and context information
+
+### For Terminal Output
+1. Select text in the terminal
+2. Press `Cmd+Shift+'` (Mac) or run command "WCGW: Send Terminal Selection to Application"
+3. Enter helpful text/instructions (or press Escape for default)
+4. Extension will:
+   - Switch to Claude
+   - Type your instructions
+   - Include terminal output and context information
 
 ## Example Output
 
-With code selected:
+### Editor Selection
 ```
-Your instructions or "Here's the code context to analyze."
+Your instructions or "Here's the code to analyze."
 
 ---
-Selected Code:
+Workspace path: /path/to/workspace
+---
+File path: /path/to/file
+---
+Selected code:
 ```
 [your selected code]
 ```
-
-File: /path/to/file
-Workspace: /path/to/workspace
 ```
 
-Without code selected:
+### Terminal Selection
 ```
-Your instructions or "Here's the code context to analyze."
+Your instructions or "Here's the terminal output to analyze."
 
-File: /path/to/file
-Workspace: /path/to/workspace
+---
+Workspace path: /path/to/workspace
+---
+Terminal output:
+```
+[your terminal selection]
+```
 ```
 
 ## Extension Settings
@@ -59,6 +76,14 @@ This extension contributes the following settings:
 - macOS only currently
 
 ## Release Notes
+
+### 0.1.0
+
+Added features:
+- Split into separate editor and terminal commands
+- New keybinding (Cmd+Shift+') for terminal selections
+- Improved error messages and context information
+- Better formatting of output
 
 ### 0.0.1
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
                 "command": "wcgw.sendToApp",
                 "key": "cmd+'",
                 "mac": "cmd+'",
-                "when": "editorTextFocus && !inDebugRepl && !terminalFocus"
+                "when": "(editorTextFocus || terminalFocus) && !inDebugRepl"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "https://github.com/rusiaaman/wcgw-vscode"
     },
-    "version": "0.0.6",
+    "version": "0.1.0",
     "engines": {
         "vscode": "^1.85.0"
     },

--- a/package.json
+++ b/package.json
@@ -21,8 +21,12 @@
     "contributes": {
         "commands": [
             {
-                "command": "wcgw.sendToApp",
-                "title": "WCGW: Send to Application"
+                "command": "wcgw.sendEditorToApp",
+                "title": "WCGW: Send Editor Selection to Application"
+            },
+            {
+                "command": "wcgw.sendTerminalToApp",
+                "title": "WCGW: Send Terminal Selection to Application"
             }
         ],
         "configuration": {
@@ -37,10 +41,16 @@
         },
         "keybindings": [
             {
-                "command": "wcgw.sendToApp",
+                "command": "wcgw.sendEditorToApp",
                 "key": "cmd+'",
                 "mac": "cmd+'",
-                "when": "(editorTextFocus || terminalFocus) && !inDebugRepl"
+                "when": "editorTextFocus && !inDebugRepl"
+            },
+            {
+                "command": "wcgw.sendTerminalToApp",
+                "key": "cmd+'",
+                "mac": "cmd+'",
+                "when": "terminalFocus && !inDebugRepl"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "https://github.com/rusiaaman/wcgw-vscode"
     },
-    "version": "0.0.5",
+    "version": "0.0.6",
     "engines": {
         "vscode": "^1.85.0"
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,35 +129,41 @@ function formatContent(
     // Add separator
     contentBlocks.push('\n---');
 
-    // Add file paths
-    if (editorContent.text && terminalContent.text) {
-        contentBlocks.push(`File path: Terminal and ${editorContent.path}`);
-    } else if (editorContent.text) {
+    // Always add workspace path at the start if any content exists
+    if (editorContent.text || terminalContent.text) {
+        contentBlocks.push(`Workspace path: ${workspacePath}`);
+        contentBlocks.push('---');
+    }
+
+    // Handle different combinations of content
+    if (editorContent.text && !terminalContent.text) {
+        // Only editor content
         contentBlocks.push(`File path: ${editorContent.path}`);
-    } else if (terminalContent.text) {
-        contentBlocks.push('File path: Terminal');
-    }
-
-    contentBlocks.push(`Workspace path: ${workspacePath}`);
-    contentBlocks.push('---');
-    contentBlocks.push('Selected Code:');
-    contentBlocks.push('```');
-
-    // Add content blocks
-    if (terminalContent.text && editorContent.text) {
-        contentBlocks.push(
-            'Terminal selection:',
-            terminalContent.text,
-            '\nEditor selection:',
-            editorContent.text
-        );
-    } else if (editorContent.text) {
+        contentBlocks.push('---');
+        contentBlocks.push('Editor selection:');
+        contentBlocks.push('```');
         contentBlocks.push(editorContent.text);
-    } else if (terminalContent.text) {
+        contentBlocks.push('```');
+    } else if (!editorContent.text && terminalContent.text) {
+        // Only terminal content
+        contentBlocks.push('Terminal selection:');
+        contentBlocks.push('```');
         contentBlocks.push(terminalContent.text);
+        contentBlocks.push('```');
+    } else if (editorContent.text && terminalContent.text) {
+        // Both editor and terminal content
+        contentBlocks.push(`File path: ${editorContent.path}`);
+        contentBlocks.push('---');
+        contentBlocks.push('Editor selection:');
+        contentBlocks.push('```');
+        contentBlocks.push(editorContent.text);
+        contentBlocks.push('```');
+        contentBlocks.push('---');
+        contentBlocks.push('Terminal selection:');
+        contentBlocks.push('```');
+        contentBlocks.push(terminalContent.text);
+        contentBlocks.push('```');
     }
-
-    contentBlocks.push('```');
 
     return {
         firstLine,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,14 +43,14 @@ export function activate(context: vscode.ExtensionContext) {
             ...(hasSelection ? [
                 "\n",
                 "---",
+                `File path: ${filePath}`,
+                `Workspace path: ${workspacePath}`,
+                "---",
                 "Selected Code:",
                 "```",
                 selectedText,
                 "```",
             ] : []),
-            "",
-            `File: ${filePath}`,
-            `Workspace: ${workspacePath}`
         ].join('\n');
 
         // Copy to clipboard and ensure it's complete

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,9 +13,16 @@ export function activate(context: vscode.ExtensionContext) {
         
         const editor = vscode.window.activeTextEditor;
         const terminal = vscode.window.activeTerminal;
-        const terminalFocused = await vscode.commands.executeCommand('workbench.action.terminal.isFocused');
-
-        if (terminalFocused && terminal) {  // Terminal is focused and exists
+        
+        // First try editor - if it's focused and has a selection, use that
+        if (editor && editor === vscode.window.activeTextEditor) {
+            const selection = editor.selection;
+            selectedText = editor.document.getText(selection);
+            hasSelection = selectedText.trim().length > 0;
+            filePath = editor.document.uri.fsPath;
+        } 
+        // If no editor or no selection in editor, try terminal
+        else if (terminal) {  // Terminal exists
             try {
                 // For terminal, we need to:
                 // 1. Store current clipboard

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,12 @@ export function activate(context: vscode.ExtensionContext) {
         const terminal = vscode.window.activeTerminal;
         const inTerminal = terminal && !editor;
         
-        if (terminal) {
+        if (editor) {
+            const selection = editor.selection;
+            selectedText = editor.document.getText(selection);
+            hasSelection = selectedText.trim().length > 0;
+            filePath = editor.document.uri.fsPath;
+        } else if (terminal && terminal.exitStatus === undefined) {  // Check if terminal is still active
             try {
                 // For terminal, we need to:
                 // 1. Store current clipboard
@@ -49,11 +54,6 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showErrorMessage('Failed to get terminal content');
                 return;
             }
-        } else if (editor) {
-            const selection = editor.selection;
-            selectedText = editor.document.getText(selection);
-            hasSelection = selectedText.trim().length > 0;
-            filePath = editor.document.uri.fsPath;
         } else {
             vscode.window.showErrorMessage('No active editor or terminal found');
             return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,14 +13,9 @@ export function activate(context: vscode.ExtensionContext) {
         
         const editor = vscode.window.activeTextEditor;
         const terminal = vscode.window.activeTerminal;
-        const inTerminal = terminal && !editor;
-        
-        if (editor) {
-            const selection = editor.selection;
-            selectedText = editor.document.getText(selection);
-            hasSelection = selectedText.trim().length > 0;
-            filePath = editor.document.uri.fsPath;
-        } else if (terminal && terminal.exitStatus === undefined) {  // Check if terminal is still active
+        const terminalFocused = await vscode.commands.executeCommand('workbench.action.terminal.isFocused');
+
+        if (terminalFocused && terminal) {  // Terminal is focused and exists
             try {
                 // For terminal, we need to:
                 // 1. Store current clipboard
@@ -54,6 +49,11 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showErrorMessage('Failed to get terminal content');
                 return;
             }
+        } else if (editor) {  // Use editor if terminal is not focused
+            const selection = editor.selection;
+            selectedText = editor.document.getText(selection);
+            hasSelection = selectedText.trim().length > 0;
+            filePath = editor.document.uri.fsPath;
         } else {
             vscode.window.showErrorMessage('No active editor or terminal found');
             return;


### PR DESCRIPTION
Splits the single command into separate editor and terminal commands with distinct keybindings (cmd+' for editor, cmd+shift+' for terminal)